### PR TITLE
Add basic support for string attributes

### DIFF
--- a/components/zigbee/zigbee.cpp
+++ b/components/zigbee/zigbee.cpp
@@ -31,6 +31,28 @@ uint8_t *get_character_string(std::string str) {
   return cstr;
 }
 
+/**
+ * Creates a ZCL string from the given input string.
+ *
+ * @param str          Pointer to the input null-terminated C-style string.
+ * @param max_size     Maximum allowable size for the resulting ZCL string. Maximum value: 254.
+ * @param use_max_size Optional. If true, the `max_size` is used directly,
+ *                     overriding the actual size of the input string.
+ * @return             Pointer to a dynamically allocated ZCL string.
+ *                     NOTE: Caller is responsible for freeing the allocated memory with `delete[]`.
+ *
+ */
+uint8_t *get_zcl_string(const char *str, uint8_t max_size, bool use_max_size) {
+  uint8_t str_len = static_cast<uint8_t>(strlen(str));
+  uint8_t zcl_str_size = use_max_size ? max_size : std::min(max_size, str_len);
+
+  uint8_t *zcl_str = new uint8_t[zcl_str_size + 1];  // string + length octet
+  zcl_str[0] = zcl_str_size;
+  memcpy(zcl_str + 1, str, str_len);
+
+  return zcl_str;
+}
+
 static void bdb_start_top_level_commissioning_cb(uint8_t mode_mask) {
   if (esp_zb_bdb_start_top_level_commissioning(mode_mask) != ESP_OK) {
     ESP_LOGE(TAG, "Start network steering failed!");

--- a/components/zigbee/zigbee_attribute.cpp
+++ b/components/zigbee/zigbee_attribute.cpp
@@ -26,7 +26,7 @@ void ZigBeeAttribute::set_attr(const std::string &str) {
   }
 
   size_t str_len = 0;
-  str_len = std::min(static_cast<std::string::size_type>(254), str.size());
+  str_len = std::min(static_cast<std::string::size_type>(this->max_size_), str.size());
   char *zcl_str = new char[str_len + 1];  // string + length octet
   ZB_ZCL_SET_STRING_VAL(zcl_str, str.c_str(), str_len);
 

--- a/components/zigbee/zigbee_attribute.cpp
+++ b/components/zigbee/zigbee_attribute.cpp
@@ -20,6 +20,20 @@ void ZigBeeAttribute::set_attr_() {
   }
 }
 
+void ZigBeeAttribute::set_attr(const std::string &str) {
+  if (this->value_p != nullptr) {
+    delete[](char *) this->value_p;
+  }
+
+  size_t str_len = 0;
+  str_len = std::min(static_cast<std::string::size_type>(254), str.size() + 1);  // string length + null-termination
+  char *zcl_str = new char[str_len + 1];                                         // string + length octet
+  ZB_ZCL_SET_STRING_VAL(zcl_str, str.c_str(), str_len);
+
+  this->value_p = (void *) zcl_str;
+  this->set_attr_requested_ = true;
+}
+
 void ZigBeeAttribute::set_report() {
   this->zb_->set_report(this->endpoint_id_, this->cluster_id_, this->role_, this->attr_id_);
 }

--- a/components/zigbee/zigbee_attribute.cpp
+++ b/components/zigbee/zigbee_attribute.cpp
@@ -26,8 +26,8 @@ void ZigBeeAttribute::set_attr(const std::string &str) {
   }
 
   size_t str_len = 0;
-  str_len = std::min(static_cast<std::string::size_type>(254), str.size() + 1);  // string length + null-termination
-  char *zcl_str = new char[str_len + 1];                                         // string + length octet
+  str_len = std::min(static_cast<std::string::size_type>(254), str.size());
+  char *zcl_str = new char[str_len + 1];  // string + length octet
   ZB_ZCL_SET_STRING_VAL(zcl_str, str.c_str(), str_len);
 
   this->value_p = (void *) zcl_str;

--- a/components/zigbee/zigbee_attribute.cpp
+++ b/components/zigbee/zigbee_attribute.cpp
@@ -25,11 +25,7 @@ void ZigBeeAttribute::set_attr(const std::string &str) {
     delete[](char *) this->value_p;
   }
 
-  size_t str_len = 0;
-  str_len = std::min(static_cast<std::string::size_type>(this->max_size_), str.size());
-  char *zcl_str = new char[str_len + 1];  // string + length octet
-  ZB_ZCL_SET_STRING_VAL(zcl_str, str.c_str(), str_len);
-
+  auto zcl_str = get_zcl_string(str.c_str(), str.size());
   this->value_p = (void *) zcl_str;
   this->set_attr_requested_ = true;
 }

--- a/components/zigbee/zigbee_attribute.h
+++ b/components/zigbee/zigbee_attribute.h
@@ -30,7 +30,7 @@ class ZigBeeAttribute : public Component {
   // void dump_config() override;
   void loop() override;
 
-  template<typename T> void add_attr(uint8_t attr_access, T value_p);
+  template<typename T> void add_attr(uint8_t attr_access, uint8_t max_size, T value_p);
   void set_report();
   template<typename T> void set_attr(T *value_p);
   void set_attr(const std::string &str);
@@ -65,9 +65,9 @@ class ZigBeeAttribute : public Component {
   bool set_attr_requested_{false};
 };
 
-template<typename T> void ZigBeeAttribute::add_attr(uint8_t attr_access, T value_p) {
+template<typename T> void ZigBeeAttribute::add_attr(uint8_t attr_access, uint8_t max_size, T value_p) {
   this->zb_->add_attr(this, this->endpoint_id_, this->cluster_id_, this->role_, this->attr_id_, this->attr_type_,
-                      attr_access, value_p);
+                      attr_access, max_size, value_p);
 }
 
 template<typename T> void ZigBeeAttribute::set_attr(T *value_p) {

--- a/components/zigbee/zigbee_attribute.h
+++ b/components/zigbee/zigbee_attribute.h
@@ -74,9 +74,7 @@ template<typename T> void ZigBeeAttribute::add_attr(uint8_t attr_access, uint8_t
 
 template<typename T> void ZigBeeAttribute::set_attr(T *value_p) {
   if constexpr (std::is_same<T, const char>::value || std::is_same<T, char>::value) {
-    size_t str_len = std::min(static_cast<size_t>(this->max_size_), strlen(value_p));
-    char *zcl_str = new char[str_len + 1];  // string + length octet
-    ZB_ZCL_SET_STRING_VAL(zcl_str, value_p, str_len);
+    auto zcl_str = get_zcl_string(value_p, this->max_size_);
 
     if (this->value_p != nullptr) {
       delete[](char *) this->value_p;

--- a/components/zigbee/zigbee_attribute.h
+++ b/components/zigbee/zigbee_attribute.h
@@ -59,6 +59,7 @@ class ZigBeeAttribute : public Component {
   uint8_t role_;
   uint16_t attr_id_;
   uint8_t attr_type_;
+  uint8_t max_size_;
   float scale_;
   CallbackManager<void(esp_zb_zcl_attribute_t attribute)> on_value_callback_{};
   void *value_p{nullptr};
@@ -66,13 +67,14 @@ class ZigBeeAttribute : public Component {
 };
 
 template<typename T> void ZigBeeAttribute::add_attr(uint8_t attr_access, uint8_t max_size, T value_p) {
+  this->max_size_ = max_size;
   this->zb_->add_attr(this, this->endpoint_id_, this->cluster_id_, this->role_, this->attr_id_, this->attr_type_,
                       attr_access, max_size, value_p);
 }
 
 template<typename T> void ZigBeeAttribute::set_attr(T *value_p) {
   if constexpr (std::is_same<T, const char>::value || std::is_same<T, char>::value) {
-    size_t str_len = std::min(static_cast<size_t>(254), strlen(value_p));
+    size_t str_len = std::min(static_cast<size_t>(this->max_size_), strlen(value_p));
     char *zcl_str = new char[str_len + 1];  // string + length octet
     ZB_ZCL_SET_STRING_VAL(zcl_str, value_p, str_len);
 


### PR DESCRIPTION
This PR adds support for ZCL Character strings as type for custom attributes.
Long character and octet strings are currently not supported.

Fixes #31.