### PR TITLE
Correct xyY to R'G'B' conversions

### DIFF
--- a/components/zigbee/automation.cpp
+++ b/components/zigbee/automation.cpp
@@ -1,23 +1,43 @@
 #include "automation.h"
+#include <algorithm>
 #include "esphome/core/log.h"
 
 namespace esphome {
 namespace zigbee {
 
+/**
+ * @brief sRGB to R'G'B' gamma correction as outlined in
+ *        https://en.wikipedia.org/wiki/SRGB
+ *
+ * @param linear a component value in sRGB color space
+ * @return float the corresponding component value in R'G'B' color space
+ */
+inline float gamma_correct(float linear) {
+  if(linear < 0.0031308f) {
+    return linear * 12.92f;
+  } else {
+    return (1.055f) * pow(linear, (1.0f / 2.4f)) - 0.055f;
+  }
+}
+
+/* The following conversions operate on xyY with Y = 1.0, hence Y
+   doesn't appear in the formulas. The coefficients originate from
+   https://en.wikipedia.org/wiki/SRGB#Primaries
+ */
 float get_r_from_xy(float x, float y) {
   float z = 1.0f - x - y;
   float X = x / y;
   float Z = z / y;
-  float r = X * 1.4628067f - 0.1840623f - Z * 0.2743606f;
-  return r <= 0.0031308f ? 12.92f * r : (1.0f + 0.055f) * pow(r, (1.0f / 2.4f)) - 0.055f;
+  float r = X * 3.2406 - 1.5372f - Z * 0.4986f;
+  return std::clamp(gamma_correct(r), 0.0f, 1.0f);
 }
 
 float get_g_from_xy(float x, float y) {
   float z = 1.0f - x - y;
   float X = x / y;
   float Z = z / y;
-  float g = -X * 0.5217933f + 1.4472381f + Z * 0.0677227f;
-  return g <= 0.0031308f ? 12.92f * g : (1.0f + 0.055f) * pow(g, (1.0f / 2.4f)) - 0.055f;
+  float g = -X * 0.9689f + 1.8758f + Z * 0.0415f;
+  return std::clamp(gamma_correct(g), 0.0f, 1.0f);
 }
 
 float get_b_from_xy(float x, float y) {
@@ -25,9 +45,8 @@ float get_b_from_xy(float x, float y) {
   float X = x / y;
   float Z = z / y;
 
-  float b = X * 0.0349342f - 0.0968930f + Z * 1.2884099f;
-
-  return b <= 0.0031308f ? 12.92f * b : (1.0f + 0.055f) * pow(b, (1.0f / 2.4f)) - 0.055f;
+  float b = X * 0.0557f - 0.2040f + Z * 1.0570f;
+  return std::clamp(gamma_correct(b), 0.0f, 1.0f);
 }
 
 #ifdef USE_LIGHT


### PR DESCRIPTION
I found that the xyY to RGB conversions did not result in the expected colors.

This patch fixes the matrix coefficients in the conversion of XYZ to R'G'B'. The coefficients and gamma correction formula originate from https://en.wikipedia.org/wiki/SRGB#Primaries

The gamma correction is added as an inline function, and clamping is performed so the resulting RGB values are in the `[0..1]` range