### PR TITLE
Update zigbee.cpp

### DIFF
--- a/components/zigbee/zigbee.cpp
+++ b/components/zigbee/zigbee.cpp
@@ -92,15 +92,21 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
           global_zigbee->searchBindings();
         }
       } else {
-        if (init_retry_count == 0) {
+        if (init_retry_count < 3) {
           ESP_LOGE(TAG, "FIRST_START.  Device started up in %sfactory-reset mode with an error %d (%s)",
                    esp_zb_bdb_is_factory_new() ? "" : "non ", err_status, esp_err_to_name(err_status));
-          ESP_LOGW(TAG, "Failed to initialize Zigbee stack (status: %s), will retry every 15s",
-                   esp_err_to_name(err_status));
+          ESP_LOGW(TAG, "Failed to initialize Zigbee stack (status: %s)", esp_err_to_name(err_status));
+          init_retry_count++;
+          esp_zb_scheduler_alarm((esp_zb_callback_t) bdb_start_top_level_commissioning_cb,
+                                 ESP_ZB_BDB_MODE_INITIALIZATION, 1000);
+        } else {
+          if (init_retry_count == 3) {
+            ESP_LOGW(TAG, "Zigbee stack init still failing, switching to 15s retry interval");
+          }
+          if (init_retry_count < 4) init_retry_count++;
+          esp_zb_scheduler_alarm((esp_zb_callback_t) bdb_start_top_level_commissioning_cb,
+                                 ESP_ZB_BDB_MODE_INITIALIZATION, 15000);
         }
-        init_retry_count++;
-        esp_zb_scheduler_alarm((esp_zb_callback_t) bdb_start_top_level_commissioning_cb,
-                               ESP_ZB_BDB_MODE_INITIALIZATION, 15000);
       }
       break;
     case ESP_ZB_BDB_SIGNAL_STEERING:

--- a/components/zigbee/zigbee.cpp
+++ b/components/zigbee/zigbee.cpp
@@ -64,6 +64,7 @@ void ZigBeeComponent::report() {
 
 void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
   static uint8_t steering_retry_count = 0;
+  static uint8_t init_retry_count = 0;
   uint32_t *p_sg_p = signal_struct->p_app_signal;
   esp_err_t err_status = signal_struct->esp_err_status;
   esp_zb_app_signal_type_t sig_type = (esp_zb_app_signal_type_t) *p_sg_p;
@@ -82,6 +83,7 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
       if (err_status == ESP_OK) {
         ESP_LOGD(TAG, "Device started up in %sfactory-reset mode", esp_zb_bdb_is_factory_new() ? "" : "non ");
         global_zigbee->started_ = true;
+        init_retry_count = 0;
         if (esp_zb_bdb_is_factory_new()) {
           ESP_LOGD(TAG, "Start network steering");
           esp_zb_bdb_start_top_level_commissioning(ESP_ZB_BDB_MODE_NETWORK_STEERING);
@@ -90,11 +92,15 @@ void esp_zb_app_signal_handler(esp_zb_app_signal_t *signal_struct) {
           global_zigbee->searchBindings();
         }
       } else {
-        ESP_LOGE(TAG, "FIRST_START.  Device started up in %sfactory-reset mode with an error %d (%s)",
-                 esp_zb_bdb_is_factory_new() ? "" : "non ", err_status, esp_err_to_name(err_status));
-        ESP_LOGW(TAG, "Failed to initialize Zigbee stack (status: %s)", esp_err_to_name(err_status));
-        esp_zb_scheduler_alarm((esp_zb_callback_t) bdb_start_top_level_commissioning_cb, ESP_ZB_BDB_MODE_INITIALIZATION,
-                               1000);
+        if (init_retry_count == 0) {
+          ESP_LOGE(TAG, "FIRST_START.  Device started up in %sfactory-reset mode with an error %d (%s)",
+                   esp_zb_bdb_is_factory_new() ? "" : "non ", err_status, esp_err_to_name(err_status));
+          ESP_LOGW(TAG, "Failed to initialize Zigbee stack (status: %s), will retry every 15s",
+                   esp_err_to_name(err_status));
+        }
+        init_retry_count++;
+        esp_zb_scheduler_alarm((esp_zb_callback_t) bdb_start_top_level_commissioning_cb,
+                               ESP_ZB_BDB_MODE_INITIALIZATION, 15000);
       }
       break;
     case ESP_ZB_BDB_SIGNAL_STEERING:


### PR DESCRIPTION
Eliminate ESP_FAIL logspam on failure to join network, and increase retry timer to 15 s.

From:
```
[16:43:24][D][zigbee:064]: Updating time sync from Zigbee network...
[16:43:24][E][zigbee:093][Zigbee_main]: FIRST_START.  Device started up in non factory-reset mode with an error -1 (ESP_FAIL)
[16:43:24][W][zigbee:095][Zigbee_main]: Failed to initialize Zigbee stack (status: ESP_FAIL)
[16:43:28][E][zigbee:093][Zigbee_main]: FIRST_START.  Device started up in non factory-reset mode with an error -1 (ESP_FAIL)
[16:43:28][W][zigbee:095][Zigbee_main]: Failed to initialize Zigbee stack (status: ESP_FAIL)
[16:43:31][E][zigbee:093][Zigbee_main]: FIRST_START.  Device started up in non factory-reset mode with an error -1 (ESP_FAIL)
[16:43:31][W][zigbee:095][Zigbee_main]: Failed to initialize Zigbee stack (status: ESP_FAIL)
...
[16:46:51][E][zigbee:093][Zigbee_main]: FIRST_START.  Device started up in non factory-reset mode with an error -1 (ESP_FAIL)
[16:46:51][W][zigbee:095][Zigbee_main]: Failed to initialize Zigbee stack (status: ESP_FAIL)
[16:46:54][D][zigbee:168][Zigbee_main]: Binding table record: src_endp 2, dst_endp 1, cluster_id 0x0006, dst_addr_mode 3
```
to:

```
[17:20:46][E][zigbee:096][Zigbee_main]: FIRST_START.  Device started up in non factory-reset mode with an error -1 (ESP_FAIL)
[17:20:46][W][zigbee:098][Zigbee_main]: Failed to initialize Zigbee stack (status: ESP_FAIL), will retry every 15s
...
[17:21:04][D][zigbee:174][Zigbee_main]: Binding table record: src_endp 2, dst_endp 1, cluster_id 0x0006, dst_addr_mode 3
```