### PR TITLE
Fix crash in find_attr during code generation

### DIFF
--- a/components/zigbee/__init__.py
+++ b/components/zigbee/__init__.py
@@ -422,8 +422,9 @@ def find_attr(conf, id):
     for ep in conf[CONF_ENDPOINTS]:
         for cl in ep.get(CONF_CLUSTERS, []):
             for attr in cl.get(CONF_ATTRIBUTES, []):
-                if attr[CONF_ID] == id:
-                    return attr
+                if CONF_ID in attr:
+                    if attr[CONF_ID] == id:
+                        return attr
     raise EsphomeError(f"Zigbee: Cannot find attribute {id}.")
 
 

--- a/components/zigbee/__init__.py
+++ b/components/zigbee/__init__.py
@@ -422,9 +422,8 @@ def find_attr(conf, id):
     for ep in conf[CONF_ENDPOINTS]:
         for cl in ep.get(CONF_CLUSTERS, []):
             for attr in cl.get(CONF_ATTRIBUTES, []):
-                if CONF_ID in attr:
-                    if attr[CONF_ID] == id:
-                        return attr
+                if attr.get(CONF_ID) == id:
+                    return attr
     raise EsphomeError(f"Zigbee: Cannot find attribute {id}.")
 
 


### PR DESCRIPTION
If cluster attributes without `id` are defined (say, for static values that are mandatory per ZCL but never need to be referenced within the device configuration and as such don't need an `id`), while other attributes are referenced by `zigbee.setAttr`, code generation would fail with a `KeyError` in `find_attr`:

```
INFO Generating C++ source...
Traceback (most recent call last):
  File "/usr/local/bin/esphome", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/esphome/esphome/__main__.py", line 2637, in main
    return run_esphome(sys.argv)
  File "/esphome/esphome/__main__.py", line 2629, in run_esphome
    return POST_CONFIG_ACTIONS[args.command](args, config)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/esphome/esphome/__main__.py", line 1564, in command_compile
    exit_code = write_cpp(config)
  File "/esphome/esphome/__main__.py", line 736, in write_cpp
    generate_cpp_contents(config)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/esphome/esphome/__main__.py", line 750, in generate_cpp_contents
    CORE.flush_tasks()
    ~~~~~~~~~~~~~~~~^^
  File "/esphome/esphome/core/__init__.py", line 945, in flush_tasks
    self.event_loop.flush_tasks()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/esphome/esphome/coroutine.py", line 355, in flush_tasks
    next(task.iterator)
    ~~~~^^^^^^^^^^^^^^^
  File "/esphome/esphome/__main__.py", line 718, in wrapped
    await coro(conf)
  File "/esphome/esphome/components/speed/fan/__init__.py", line 37, in to_code
    var = await fan.new_fan(config, config[CONF_SPEED_COUNT])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/esphome/esphome/components/fan/__init__.py", line 308, in new_fan
    await register_fan(var, config)
  File "/esphome/esphome/components/fan/__init__.py", line 303, in register_fan
    await setup_fan_core_(var, config)
  File "/esphome/esphome/core/entity_helpers.py", line 401, in wrapper
    await func(var, config, *args, **kwargs)
  File "/esphome/esphome/components/fan/__init__.py", line 277, in setup_fan_core_
    await automation.build_automation(trigger, [(Fan.operator("ptr"), "x")], conf)
  File "/esphome/esphome/automation.py", line 673, in build_automation
    actions = await build_action_list(config[CONF_THEN], templ, args)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/esphome/esphome/automation.py", line 620, in build_action_list
    action = await build_action(conf, templ, arg_type)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/esphome/esphome/automation.py", line 612, in build_action
    return await builder(config, action_id, template_arg, args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/external_components/1e1099b9/components/zigbee/__init__.py", line 726, in zigbee_set_attr_to_code
    attr = find_attr(
        CORE.config["zigbee"],
        config[CONF_ID],
    )
  File "/data/external_components/1e1099b9/components/zigbee/__init__.py", line 425, in find_attr
    if attr[CONF_ID] == id:
       ~~~~^^^^^^^^^
KeyError: 'id'
```

A simple extra check fixes that.